### PR TITLE
Add typescript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,34 @@ fastify.listen(3000, err => {
 })
 ```
 
+**With Typescript**
+
+```typescript
+import fastify from 'fastify'
+import fastifyMongoose, { FastifyMongooseOptions } from 'fastify-mongoose'
+
+const options: FastifyMongooseOptions = {
+  uri: 'mongodb://localhost/test_db',
+  name: 'mongo' // Optional, the name to decorate fastify
+}
+
+fastify.register(fastifyMongoose, )
+
+fastify.listen(3000, err => {
+  if (err) throw err
+  console.log(`server listening on ${fastify.server.address().port}`)
+})
+
+declare module 'fastify' {
+  import { Connection, ObjectId } from 'mongoose';
+
+  mongo: { // needs to be the same name in options
+    db: Connection;
+    ObjectId: ObjectId;
+  }
+}
+```
+
 ##### Breaking changes
 `"version": "0.3.0` and above plugin have ability to open connection with multiple different databases, for achieving this functionality it have to stop using default mongoose connection. Onward please use db client returned by this plugin.
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ fastify.listen(3000, err => {
 declare module 'fastify' {
   import { Connection, ObjectId } from 'mongoose';
 
-  mongo: { // needs to be the same name in options
-    db: Connection;
-    ObjectId: ObjectId;
+  interface FastifyInstance {
+    mongo: { // needs to be the same name in options
+      db: Connection;
+      ObjectId: ObjectId;
+    }
   }
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+import { FastifyPlugin } from 'fastify';
+import { ConnectOptions } from 'mongoose';
+
+export interface FastifyMongooseOptions extends ConnectOptions {
+  /**
+   * Connection string to your MongoDB instance
+   */
+  uri: string;
+  /**
+   * Name of the plugin, default: mongo
+   */
+  name?: string;
+}
+
+export const fastifyMongoose: FastifyPlugin<FastifyMongooseOptions>;
+export default fastifyMongoose;


### PR DESCRIPTION
Add missing types, so, this plugin can be used with Typescript.  
Update README.md to show an example with Typescript.

CLOSE #8